### PR TITLE
Make this works on windows too

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -3,4 +3,4 @@
 var spawn = require('child_process').spawn
 var npm = require.resolve('npm/cli')
 
-spawn(npm, process.argv.slice(2), {stdio: 'inherit'})
+spawn(process.execPath, [npm].concat(process.argv.slice(2)), {stdio: 'inherit'})


### PR DESCRIPTION
In windows, it is impossible to just `spawn` a `js` file, related issue: https://github.com/timoxley/npm3/issues/1 .

So make `node` to run such will be working good.
